### PR TITLE
Make everything not clickable in the backend

### DIFF
--- a/dev/sass/editor-styles.scss
+++ b/dev/sass/editor-styles.scss
@@ -2,3 +2,13 @@
 .editor-styles-wrapper {
   @import 'styles';
 }
+
+.wp-block[data-type*='gravityforms'],
+.wp-block .acf-block-preview {
+
+  // Make everything not clickable in the backend
+	a {
+		pointer-events: none !important;
+		cursor: default !important;
+	}
+}


### PR DESCRIPTION
Wanneer je bijvoorbeeld een ACF Gallery inzet en deze dan rendered zodat je erop kan klikken. Dan ga je vanuit je WordPress Dashboard ineens naar deze afbeelding.

Je kan op een link dan speciaal voor de backend dan `pointer-events: none;` plaatsen.