### PR TITLE
Update the asset loading by Utility class

### DIFF
--- a/functions/init.php
+++ b/functions/init.php
@@ -65,15 +65,17 @@
      * @see https://developer.wordpress.org/reference/hooks/after_setup_theme/
      */
     add_action('after_setup_theme', function() use ($utilities, $gutenberg) {
-		$mixPublicPath = get_template_directory() . '/build';
+		
+		// Set the mix manifest location
+		$utilities->assets->set_manifest_location( '/build/mix-manifest.json' );
 
         // Setup the scripts to enqueue
-		$utilities->assets->register('script', 'jquery', 'https://code.jquery.com/jquery-3.6.0.min.js', array(), true);
-		$utilities->assets->register('script', 'scripts', get_template_directory_uri()  . '/build' . mix("scripts/scripts.js", $mixPublicPath), array(), false);
+		$utilities->assets->register('theme', 'script', 'jquery', 'https://code.jquery.com/jquery-3.6.0.min.js', array(), true);
+		$utilities->assets->register('theme', 'script', 'scripts', $utilities->assets->get_file_from_manifest( 'scripts/scripts.js' ), array(), false);
 
 		// Setup styles to enqueue
-		$utilities->assets->register('style', 'fonts', '//fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,300;1,400;1,500;1,600;1,700;1,800&display=swap', array(), true);
-		$utilities->assets->register('style', 'styles', get_template_directory_uri()  . '/build' .  mix('styles/styles.css', $mixPublicPath), array(), true);
+		$utilities->assets->register('theme', 'style', 'fonts', '//fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,300;1,400;1,500;1,600;1,700;1,800&display=swap', array(), true);
+		$utilities->assets->register('theme', 'style', 'styles', $utilities->assets->get_file_from_manifest( 'styles/styles.css' ), array(), true);
 
         // Add ajaxurl als default param to scripts
         $utilities->assets->localize('scripts', 'theme', array(
@@ -81,19 +83,18 @@
         ));
 
 		// Editor styles		
-		add_editor_style('/build/styles/editor-styles.css');
+		$utilities->assets->add_editor_style('/build/styles/editor-styles.css');
 		
-		// Enqueue gutenberg assets
-		add_action('enqueue_block_editor_assets', 'enqueue_block_editor_assets');
-		
-		function enqueue_block_editor_assets() {
-			wp_enqueue_style('open-sans', '//fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,300;1,400;1,500;1,600;1,700;1,800&display=swap');
-			wp_enqueue_script('scripts-js', get_template_directory_uri() . '/build/scripts/scripts.js');
-			wp_enqueue_script('editor-js', get_template_directory_uri() . '/build/scripts/editor.js', ['wp-blocks','wp-dom-ready', 'wp-edit-post' ]);
-		}
+        // Enqueue all assets
+        $utilities->assets->load_theme_assets();
 
-        // Enqueue all assets (keep at end of file)
-        $utilities->assets->load();
+		// Setup editor assets to enqueue
+		$utilities->assets->register('editor', 'style', 'open-sans', '//fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,300;1,400;1,500;1,600;1,700;1,800&display=swap' );
+		$utilities->assets->register('editor', 'script', 'bvdb-scripts', $utilities->assets->get_file_from_manifest( 'scripts/scripts.js' ) );
+		$utilities->assets->register('editor', 'script', 'bvdb-editor-scripts', $utilities->assets->get_file_from_manifest( 'scripts/editor.js' ), array('wp-blocks','wp-dom-ready', 'wp-edit-post') );
+
+		// Load editor assets
+		$utilities->assets->load_editor_assets();
         
         // Include the blocks
         $blocks_loaded = $gutenberg->blocks->include_blocks();
@@ -112,48 +113,4 @@
 
     }, 1);
 
-    // =================================================================================
-    // Add WooCommerce support
-    $utilities->themesupport->add('woocommerce', array());
 
-    // Temp fix for WooCommerce
-    add_filter( 'woocommerce_sort_countries', '__return_false' );
-
-    // Remove WooCommerce template loader
-    add_action('wp', function() {
-        remove_filter('template_include', 'WC_Template_Loader::template_loader' );
-    });
-    // =================================================================================
-
-
-	// Mix manifest function 
-	function mix($path, $manifestDirectory = '')
-    {
-        static $manifest;
-        if ($manifestDirectory && strpos($manifestDirectory, '/') !== 0) {
-            $manifestDirectory = "/{$manifestDirectory}";
-        }
-
-        if (! $manifest) {
-            if (! file_exists($manifestPath = $manifestDirectory.'/mix-manifest.json')) {
-                throw new Exception('The Mix manifest does not exist.');
-            }
-            $manifest = json_decode(file_get_contents($manifestPath), true);
-        }
-
-        if (strpos($path, '/') !== 0) {
-            $path = "/{$path}";
-        }
-
-        if (! array_key_exists($path, $manifest)) {
-            throw new Exception(
-                "Unable to locate Mix file: {$path}. Please check your webpack.mix.js output paths and try again."
-            );
-        }
-
-        return $manifest[$path];
-    }
-
-	// Add allowed blocks to editor
-	
-	


### PR DESCRIPTION
Changes:
- Removed mix-function and replaced it by a utility-class method which handles the parsing of the manifest.
- Requires the utility class version 0.1.1, also see updated documentation in [confluence](https://burovoordeboeg.atlassian.net/wiki/spaces/BVDBT/pages/2752551/Assets#get_file_from_manifest). 
- Also removed WooCommerce support, as this is not needed by default and is already covered in [separate Git-repository](https://github.com/burovoordeboeg/template-loader-woocommerce-twig). 
- Implemented new asset loader for the editor, please see the updated [confluence docs](https://burovoordeboeg.atlassian.net/wiki/spaces/BVDBT/pages/2752551/Assets#register)