### PR TITLE
Remove error_reporting instruction

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -3,17 +3,6 @@
 	// Exit if accessed directly
 	if ( ! defined( 'ABSPATH' ) ) exit;
 
-	// Show error reporting by default
-	// --
-	// To see live logs running inside the container
-	// --
-	// $date: 			in format YYYY-MM-DDT00:00:00
-	// $containerid:	get the id of the container with the "docker ps" 
-	// 					command running on image jstreuper/wordpress-latest
-	// --
-	// Command:
-	// docker logs -f --since=$date $containerid >/dev/null
-
 	// Initialize theme
 	include_once 'functions/init.php';
 	


### PR DESCRIPTION
When using the docker extension, it is possible to view the debug log directly in VS Code